### PR TITLE
change model clean field name

### DIFF
--- a/inplaceeditform/views.py
+++ b/inplaceeditform/views.py
@@ -54,7 +54,10 @@ def save_ajax(request):
         messages = []  # The error is for another field that you are editing
         for field_name_error, errors_field in form.errors.items():
             for error in errors_field:
-                messages.append(u"%s: %s" % (field_name_error, error))
+                if field_name_error == '__all__': # The error is model clean type
+                    messages.append(u"Error: %s" % error)
+                else:
+                    messages.append(u"%s: %s" % (field_name_error, error))
         message_i18n = ', '.join(messages)
         return _get_http_response({'errors': message_i18n})
     except ValidationError as error:  # The error is for a field that you are editing


### PR DESCRIPTION
change model clean field name from '**all**' to 'error' is convenient as less confusing to end user.
